### PR TITLE
Remove asset labelling as it's not in use

### DIFF
--- a/appendix/iso-27001.md
+++ b/appendix/iso-27001.md
@@ -97,12 +97,8 @@ All employees and external party users shall return all of the organizational as
 Objective: To ensure that information receives an appropriate level of protection in accordance with
 its importance to the organization.
 
-- [Asset Inventory](../physical/inventory.md)
-
 ####8.2.1 Classification of information
 Information shall be classified in terms of legal requirements, value, criticality and sensitivity to unauthorized disclosure or modification.
-
-- [Asset Inventory](../physical/inventory.md)
 
 ####8.2.2 Labeling of information
 An appropriate set of procedures for information labeling shall be developed and implemented in accordance with the information classification scheme adopted by the organization.

--- a/physical/inventory.md
+++ b/physical/inventory.md
@@ -11,7 +11,6 @@ This policy applies to all Lullabot employees and management.
 - Whenever a computer or cell phone is taken out of service it will be removed from the asset tracking system.
 - The system will track identifying information, including make, model, and serial number.
 - The system will track the location of the item and identify the person who has possession of it.
-- The system will include a classification system to allow each asset to be classified based on its security risk.
 
 ### Explanation and Implementation
 Lullabot tracks assets and equipment in an inventory tracking system. All computers and cell phones used for Lullabot business will be tracked in this system, regardless of who purchased them or when they were purchased. 
@@ -20,14 +19,6 @@ Lullabot tracks assets and equipment in an inventory tracking system. All comput
 Whenever a computer or cell phone is purchased with PEX or Lullabot funds, details about the asset will be entered into the inventory tracking system by administrative staff when they process the receipt. The purchaser can add the serial number and other information as a comment to the purchase in the PEX system. 
 
 If the asset is replacing an older piece of equipment, the older equipment should be removed from service at that time. The administrative staff will be responsible for determining when this should be done and following up with the person who has control of the older asset.
-
-#### Classification
-Assets in the inventory tracking system will be classified into one of the following categories:
-
-- Confidential (top confidentiality level)
-- Restricted (medium confidentiality level)
-- Internal use (lowest level of confidentiality)
-- Public (everyone can see the information or the asset provides no access to any information)
 
 #### Removing Assets From Service
 Computers and cell phones that have been replaced, or those which are being sold to employees, should be properly removed from service.


### PR DESCRIPTION
- The admin team is not labelling devices today
- We tried labels with a system called Asset Panda, but it was not a good system and now we just use a spreadsheet
- Laptops and such are bought out by employees, not sent back, so we don't have a use case for scanning barcodes and the like