### PR TITLE
Revert "Remove the .gitignore" to restore tugboat config

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,0 +1,18 @@
+services:
+  apache:
+    image: tugboatqa/httpd
+    commands:
+      init:
+        - ./debian-deps.sh
+        - mkdir -p /var/www
+        - chown www-data:www-data /var/www
+      build:
+        # Calibre uses Chrome libraries under the hood, and it refuses to run
+        # as root.
+        - mkdir -p /var/www
+        - chown www-data:www-data /var/www
+        - chown -Rv www-data:www-data /var/lib/tugboat
+        - sudo -u www-data yarn install
+        - sudo -u www-data yarn build
+        - sudo -u www-data yarn pdf _book/security.pdf
+        - ln -snf "${TUGBOAT_ROOT}/_book" "${DOCROOT}"


### PR DESCRIPTION
This reverts part of commit 73f5572ea44c9ad34e0d56af7b7ddf9fe20226e0 that accidentally removed our tugboat config.