### PR TITLE
Add missing libxtst6

### DIFF
--- a/install-calibre.sh
+++ b/install-calibre.sh
@@ -15,6 +15,7 @@ apt-get update \
   libopengl0 \
   libxi6 \
   libnss3 \
+  libxtst6 \
   python \
   wget
 


### PR DESCRIPTION
It turns out Tugboat wasn't getting webhooks from GitHub. That meant our base preview wasn't rebuilding as expected. I've fixed that (I think), but it also revealed that we're still missing some packages that GitHub Actions includes by default.