### PR TITLE
Clarify internal properties

### DIFF
--- a/access/lullabot_vpn.md
+++ b/access/lullabot_vpn.md
@@ -1,15 +1,18 @@
 ## Virtual Private Network (VPN)
 
 ### Policy
+
 The use of a virtual private network (VPN) is required when accessing Lullabot's servers, or when accessing client's assets for clients that provide VPNs. A VPN should be always be used when working from unknown or untrustworthy locations, like public networks.
 
 ### Scope
+
 This policy applies to all Lullabot employees and contractors.
 
 ### Compliance
-1. Critical assets will be available only to employees via the Lullabot VPN, like the Daily Report and edit.lullabot.com.
-2. Since employees must use the VPN to access some internal assets, their devices will  be VPN-enabled. This will make it easy to use the VPN when they are working from any untrustworthy location.
-3. Some Lullabot clients provide a VPN that is the only way that client assets can be accessed. Employees and contractors working with those clients will not be able to do their work without using the VPN.
+
+1. Critical infrastructure assets will be available only to employees via the Lullabot VPN.
+2. Since employees must use Lullabot's VPN to access some internal assets, their devices will be VPN-enabled. This will make it easy to use the VPN when they are working from any untrustworthy location.
+3. Some Lullabot clients provide a VPN that is the only way that client assets can be accessed. Employees and contractors working with those clients will not be able to do their work without using the client VPN.
 
 ### Explanation and Implementation
 
@@ -19,6 +22,6 @@ It is important to understand that this only protects your traffic as it moves f
 
 Using the VPN connection also makes all of your internet traffic appear to be coming from a Lullabot server, which means that you can connect from anywhere in the world, and as far as the greater internet is concerned, you look like you are sitting in Newark, NJ. This means that when there are access restrictions on a project, our VPN address can be added to an access control list, and you can connect from anywhere.
 
-Finally, your VPN connection bypasses any local network restrictions. For example, it is not uncommon for public wifi hotspots to block services like IRC. By connecting to the VPN, you will automatically bypass any of these network-level restrictions. It is highly encouraged to use the VPN any time you are using public wifi at a coffee shop, airport, hotel, etc. This is especially true if you are using the same computer or other device that you use for work. If in doubt, err on the side of caution and use the VPN.
+Finally, your VPN connection bypasses any local network restrictions. For example, it is not uncommon for public wifi hotspots to block services. By connecting to the VPN, you will automatically bypass any of these network-level restrictions. It is highly encouraged to use the VPN any time you are using public wifi at a coffee shop, airport, hotel, etc. This is especially true if you are using the same computer or other device that you use for work. If in doubt, err on the side of caution and use the VPN.
 
-Instructions on how to connect to Lullabot's VPN can be found at https://www.dropbox.com/work/Lullabot/VPN. 
+Employees can find instructions on how to connect to Lullabot's VPN at https://www.dropbox.com/work/Lullabot/VPN. 


### PR DESCRIPTION
We no longer host lullabot.com internally, and services may move inside and outside of our internal networks over time.

This updates the policy to indicate that we will only require infrastructure access (like Tugboat's management plane) to be over the VPN.

As well, I clarified that the VPN instructions are protected behind a valid Lullabot Dropbox account, and not public.

Link to the rich diff for review: https://github.com/Lullabot/information-security-policy/pull/103/files?short_path=e4b34e7#diff-e4b34e79630bbab376ac03d3ad30b4f99c8f3d524c64cc1ee2728c1e5ce6d469