### PR TITLE
Update team members

### DIFF
--- a/policy/leadership.md
+++ b/policy/leadership.md
@@ -17,10 +17,8 @@ The current members of the Security team include:
 
 - [Andrew Berry, Director of Technology](https://www.lullabot.com/about/andrew-berry)
 - [Brian Skowron, President](https://www.lullabot.com/about/brian-skowron)
-- [Dave Reid, Senior Developer](https://www.lullabot.com/about/dave-reid)
 - [Ezequiel Vázquez, Senior Developer](https://www.lullabot.com/about/ezequiel-vazquez)
 - [Sally Young, Senior DevOps Engineer](https://www.lullabot.com/about/sally-young)
-- [Salvador Molina Moreno, Senior Developer](https://www.lullabot.com/about/salvador-molina-moreno)
 - [Tim McDorman, Administrative Manager](https://www.lullabot.com/about/tim-mcdorman)
 
-This team is currently meeting weekly to discuss and assess security concerns. The team can be contacted at any time by sending an email to security@lullabot.com.
+This team is currently meeting weekly to discuss and assess security concerns. The team can be contacted at any time by sending an email to [security@lullabot.com](mailto:security@lullabot.com).


### PR DESCRIPTION
This removes Dave Reid and Salva Moreno as they are no longer participating in the security committee. Thanks for your work!

I've also made the email address a link.