### PR TITLE
Automatically merge dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
I've been merging updates pretty easily for the past month or two. Tugboat is configured to run visual diffs on several URLs, so if they fail well know.

https://docs.renovatebot.com/configuration-options/#automerge