### PR TITLE
Policy for Apple system updates

### DIFF
--- a/appendix/appendix.md
+++ b/appendix/appendix.md
@@ -1,3 +1,3 @@
-#Appendix
+# Appendix
 
-The appendix includes some checklists to help manage security.
+The appendix includes additional information to help manage and understand security policies at Lullabot.

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -98,6 +98,7 @@ https
 i.e.
 iCloud
 iOS
+iPadOS
 iPhones
 jailbroken
 keychain

--- a/physical/device.md
+++ b/physical/device.md
@@ -13,6 +13,7 @@ Each employee will be responsible for their own equipment.
 
 Best practices for maintenance of electronic equipment includes, but is not limited to:
 
+- Always apply the [latest security and patch releases of software](/physical/malware.html).
 - Use surge protectors.
 - Enable the firewall.
 - Procure insurance to cover potential equipment loss or damage.
@@ -22,5 +23,3 @@ Best practices for maintenance of electronic equipment includes, but is not limi
 - Consider using a separate router and SSID for personal and IoT network connections.
 
 Unlicensed software, pirated music, video, software are not permitted on Lullabot laptops, these can be a vector for malware. They can introduce vulnerabilities and lead to information leakage, loss of integrity and other information security incidents, or to violation of intellectual property rights.
-
-

--- a/physical/malware.md
+++ b/physical/malware.md
@@ -13,11 +13,31 @@ Each employee or contractor will be responsible for their own equipment.
 
 Protection against malware and viruses includes, but is not limited to:
 
+- Keeping all software up to date with the latest security patches.
 - Avoid installing unlicensed software, pirated music, video, software, these can be a vector for malware.
 - Protect devices from malware and viruses by enabling the firewall and using virus protection software.
 - Use an ad-blocker. The business model for ad networks is contrary to best security practices, making them easy targets for hackers.
 - Make Flash and Java click-to-play, Choose “Ask” rather than the default of “Allow” in Safari.
 - Install ClamAV and have it scan folders with user uploaded data.
+
+### macOS, iOS, and iPadOS Software Updates
+
+Apple only provides complete security coverage for the [latest major version](https://support.apple.com/en-ca/guide/deployment/depc4c80847a/web) of their operating systems. Employees or contractors will:
+
+1. Apply security updates to existing releases, such as `12.5`, within **one week** of their release.
+1. Upgrade to the latest major release no later than when its first "bugfix" release is issued. Updating to the initial versions of major upgrades is still highly recommended unless there is a known compatibility issue.
+
+For example, as of this writing the current releases and required versions of Apple system software are:
+
+|Operating System|Current Version|Lullabot Required Version|
+|----------------|---------------|-------------------------|
+|macOS           |13.0.1         |12.6.1 (13.0.1 preferred)|
+|iOS             |16.1.1         |16.1.1                   |
+|iPadOS          |16.1.1         |16.1.1                   |
+
+Note that Automatic Updates on macOS are easy to skip by mistake and do not always apply promptly. Watch for reminders from the Security Team to know when updates are available.
+
+If your laptop, phone, or tablet does not support the required operating system version, then it is time to replace that device with something newer.
 
 ### Ad-blocker configuration
 

--- a/physical/malware.md
+++ b/physical/malware.md
@@ -17,8 +17,7 @@ Protection against malware and viruses includes, but is not limited to:
 - Avoid installing unlicensed software, pirated music, video, software, these can be a vector for malware.
 - Protect devices from malware and viruses by enabling the firewall and using virus protection software.
 - Use an ad-blocker. The business model for ad networks is contrary to best security practices, making them easy targets for hackers.
-- Make Flash and Java click-to-play, Choose “Ask” rather than the default of “Allow” in Safari.
-- Install ClamAV and have it scan folders with user uploaded data.
+- Install ClamAV on servers and have it scan folders with user uploaded data.
 
 ### macOS, iOS, and iPadOS Software Updates
 


### PR DESCRIPTION
This PR documents the policy we've discussed over the past few meetings as Apple's security updates policy has become clear. I created an example table to try to clarify what is required, though I think in practice we'll need to send an announcement to the team every time new major releases are bumped.

I've included iOS and iPadOS as Apple's docs make clear their policy covers them too.