### PR TITLE
Remove tests in CI

### DIFF
--- a/.github/workflows/BuildGitHubPages.yml
+++ b/.github/workflows/BuildGitHubPages.yml
@@ -45,10 +45,6 @@ jobs:
         run: |
           yarn build
 
-      - name: Test
-        run: |
-          yarn test
-
       - name: Build PDF
         run: |
           sudo ./install-calibre.sh


### PR DESCRIPTION
Our automated tests check for broken links. Unfortunately, we're seeing more and more errors failing unrelated pull requests. Often, this is not due to a page no longer existing, but a site now blocking non-individual IPs.

This PR removes the CI check, but leaves it in place for locals (where we can confirm things work from an unblocked IP).